### PR TITLE
fix: note precise path of .gitignore's FB auth. file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,6 @@ app.*.map.json
 
 *.env
 firebase.json
-/**/firebase_options.dart
-/**/google-services.json
-/**/GoogleService-Info.plist
+/lib/firebase_options.dart
+/android/app/google-services.json
+/ios/Runner/GoogleService-Info.plist


### PR DESCRIPTION
# Result

## .gitignore un-remoted files

현재 .gitignore 파일 최하단에 remote로 올라가지 않는 5개의 파일를 명시해놓았습니다. 파일 경로는 다음과 같습니다.

~~~
*.env
firebase.json
/lib/firebase_options.dart
/android/app/google-services.json
/ios/Runner/GoogleService-Info.plist
~~~

파일이 공유되는 폴더는 코더빡님의 개인 서버 `팀 폴더 > swmaestro > bammer` 경로에 `7f7657a-flutter-client-local`과 같이 7자리의 shorten commit message, 현재 레포지토리명, remote에 올라가 있지 않은 파일을 공유한다는 의미로 작성합니다.

# How
## 로컬에서 main.dart를 빌드하여 테스트 하는 경우,

- 먼저 [구글 플레이의 클라이언트 인증 문서](https://developers.google.com/android/guides/client-auth?hl=ko)에서 안내하는 방법대로 서명키를 추출하여 Firebase Authentication에서 SHA 인증서 지문의 디지털 지문 추가를 하였는지 확인합니다.
- 디지털 지문을 추가하기 위해서 Firebase Authentication 콘솔에서 `톱니바퀴 아이콘 - 프로젝트 설정 - 일반`으로 이동하여 최하단에 아래 사진과 같이 추가합니다.
- /android 위치에서 `./gradlew signingReport` 명령을 실행하여 SHA1 값을 복사하는 방법이 가장 편합니다.
- 팀 공유 드라이브의 해당 경로로 접근하여 remote에 올라가 있는 않는 파일 총 5개를 수동으로 업데이트 합니다.
- **.env 파일은 레포지토리의 루트 경로에 넣습니다.**

# Screenshot
<img width="1470" alt="fbauth_digital_finger_print" src="https://github.com/user-attachments/assets/4dc4c58b-2f24-4400-82f8-b3826b9f8c91">