### PR TITLE
fix: AI processed event via main backend server #6

### DIFF
--- a/lib/widget/custom_bottom_sheet.dart
+++ b/lib/widget/custom_bottom_sheet.dart
@@ -62,18 +62,18 @@ class _CustomBottomSheetState extends State<CustomBottomSheet> {
       summary = widget.responseData?['summary'];
       summaryController.text = widget.responseData?['summary'];
 
-      if (widget.responseData?['start'] == null) {
+      if (widget.responseData?['startAt'] == null) {
         startAt = DateTime.now();
       } else {
-        startAt = DateTime.parse(widget.responseData?['start']);
+        startAt = DateTime.parse(widget.responseData?['startAt']);
       }
       // startAtController.text = DateFormat('yyyy년 M월 dd일 (EE)', 'ko_KR')
       //     .format(startAt);
 
-      if (widget.responseData?['end'] == null) {
+      if (widget.responseData?['endAt'] == null) {
         endAt = startAt.add(Duration(hours: 1));
       } else {
-        endAt = DateTime.parse(widget.responseData?['end']);
+        endAt = DateTime.parse(widget.responseData?['endAt']);
       }
       // endAtController.text = DateFormat('yyyy년 M월 dd일 (EE)', 'ko_KR')
       //     .format(endAt);
@@ -307,8 +307,8 @@ class _CustomBottomSheetState extends State<CustomBottomSheet> {
   void printResponseData() {
     if (widget.responseData != null) {
       print('${widget.responseData?['summary']}');
-      print('${widget.responseData?['start']}');
-      print('${widget.responseData?['end']}');
+      print('${widget.responseData?['startAt']}');
+      print('${widget.responseData?['endAt']}');
       print('${widget.responseData?['location']}');
       print('${widget.responseData?['description']}');
     }

--- a/lib/widget/plain_text_input.dart
+++ b/lib/widget/plain_text_input.dart
@@ -71,15 +71,17 @@ class _PlainTextInputState extends State<PlainTextInput> {
                       var refreshToken =
                           await storage.read(key: REFRESH_TOKEN_KEY);
                       final data = {
-                        'plainText': plainText,
-                        'promptId': 1,
+                        'inputType': 1,
+                        'originText': plainText,
+                        'promptId': 1
                       };
                       final jsonData = jsonEncode(data);
                       print('plainText data: $jsonData');
 
                       try {
                         var resp = await dio.post(
-                          dotenv.env['BACKEND_AI_URL']! + '/api/v1/plainText',
+                          dotenv.env['BACKEND_MAIN_URL']! +
+                              '/api/v1/eventProcessing/plainText',
                           data: jsonData,
                           options: Options(
                             headers: {

--- a/lib/widget/speech_to_text_input.dart
+++ b/lib/widget/speech_to_text_input.dart
@@ -120,7 +120,8 @@ class _SpeechToTextInputState extends State<SpeechToTextInput> {
                         var refreshToken =
                             await storage.read(key: REFRESH_TOKEN_KEY);
                         final data = {
-                          'plainText': _controller.text,
+                          'inputType': 1,
+                          'originText': _controller.text,
                           'promptId': 1
                         };
                         final jsonData = jsonEncode(data);
@@ -128,7 +129,8 @@ class _SpeechToTextInputState extends State<SpeechToTextInput> {
 
                         try {
                           var resp = await dio.post(
-                            dotenv.env['BACKEND_AI_URL']! + '/api/v1/plainText',
+                            dotenv.env['BACKEND_MAIN_URL']! +
+                                '/api/v1/eventProcessing/plainText',
                             data: jsonData,
                             options: Options(
                               headers: {


### PR DESCRIPTION
# Result

[#6](https://github.com/SWM-15th-Dnight/flutter-client/issues/6#issue-2489288946) 해당 이슈에서 추측한대로
모바일 클라이언트가 AI 서버에 직접 요청을 보내고 있기 때문에 발생하는 문제로
DB의 `ai_processing_` 이하 2개 테이블에 데이터가 적재가 안되는 문제 상황을 확인함.

# How 

현재 구현된 자연어 및 음성 입력을 통한 일정 등록 요청을 AI 서버의 /api/v1/plainText가 아닌,
메인 백엔드의 `/api/v1/eventProcessing/plainText`로 하기 위해
DTO에 맞게 수정하여 (예. 'start'에서 'startAt') 해결하였음.

# Screenshot

인앱에서 아래 summary로 자연어 및 음성 입력
둘 다 테스트한 결과 해당 테이블에 데이터가 잘 적재되는 것을 확인하였음.

MySQLWorkBench             |  In App
:-------------------------:|:-------------------------:
<img width="1188" alt="image" src="https://github.com/user-attachments/assets/7e285786-776d-4864-9d90-a2467668fc02">  |  <img src="https://github.com/user-attachments/assets/f22c12b6-fbe5-4d25-9e4d-8744285752c8" width="350">
